### PR TITLE
#84 long post titles and post descriptions now wrap text with break-word added in postpage css

### DIFF
--- a/public/css/postpage.css
+++ b/public/css/postpage.css
@@ -20,3 +20,6 @@ footer {
 .container{
     margin-top: 7.0em;
 }
+.wraptxt{
+    word-wrap: break-word;
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/custom.css">
     <link rel="stylesheet" type="text/css" href="/css/login.css">
+    <link rel="stylesheet" type="text/css" href="/css/postpage.css">
     <link href='http://fonts.googleapis.com/css?family=Berkshire+Swash' rel='stylesheet' type='text/css'>
     
     <script src="login.js"></script>

--- a/views/postpage.ejs
+++ b/views/postpage.ejs
@@ -301,7 +301,7 @@
             <% }) %>
             
             <!-- Add new comment section -->
-            <label for="addComment">Add New Comment to: <h3><%= post.title%></h3></label>
+            <label for="addComment">Add New Comment to: <h3 class="wraptxt"><%= post.title%></h3></label>
            
             <form action="/post/<%= post._id %>/user/<%= post.author.id %>/<%= post.title %>/comments" method="POST">
                 


### PR DESCRIPTION
Added postpage.css stylesheet in index.ejs
.wraptxt in postpage.css wraps long lines of text