### PR TITLE
Posting requires title to create question post

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -4,6 +4,7 @@ h2 {
   font: 400 100px/1.3 'Berkshire Swash', Helvetica, sans-serif;
   color: #2b2b2b;
   text-shadow: 1px 1px 0px #ededed, 4px 4px 0px rgba(0,0,0,0.15);
+  margin: -75px 1px 25px 1px;
 }
 
 h5 {

--- a/views/postpage.ejs
+++ b/views/postpage.ejs
@@ -203,7 +203,7 @@
                         </a>
                       </div>
                       
-                      <!-- show only if user owns th post -->
+                      <!-- show only if user owns the post -->
                       <% if (currentUser && post.author.id.equals(currentUser._id)){ %>
                         <a href="/post/<%= post._id %>/user/<%=  user._id  %>/<%= post.title %>/comments/<%= comment._id %>/bestanswer" class="ui green button">
                           Best Answer
@@ -294,8 +294,7 @@
                               <label style = "font-size: 10px;">Edit Comment</label>
                               <textarea class="form-control input-md" rows="4" name="comment"><%= comment.text %></textarea>
                             </div>
-                            <br>
-                            <button type="submit" value="submit" class="submit-post btn btn-primary">Submit</button>
+                            <button type="submit" value="submit" class="btn-xs submit-post btn btn-primary">Submit</button>
                           </form>
                         </div>
                         <% } %>
@@ -312,7 +311,8 @@
             <form action="/post/<%= post._id %>/user/<%= post.author.id %>/<%= post.title %>/comments" method="POST">
               <% if(user !== null){ %>  
               <div class="form-group">
-                <textarea class="form-control" rows="4" name="comment[text]" placeholder="Type Here"></textarea>
+                <textarea class="form-control" rows="4" name="comment[text]" placeholder="Type Here" required='' oninvalid="this.setCustomValidity('Please enter your comment!')"
+                oninput="setCustomValidity('')"></textarea>
               </div>
                 
                 <div class="form-group">

--- a/views/postpage.ejs
+++ b/views/postpage.ejs
@@ -294,7 +294,9 @@
                               <label style = "font-size: 10px;">Edit Comment</label>
                               <textarea class="form-control input-md" rows="4" name="comment"><%= comment.text %></textarea>
                             </div>
-                            <button type="submit" value="submit" class="btn-xs submit-post btn btn-primary">Submit</button>
+                            <div style="margin:7.5px -0.5px">
+                              <button type="submit" value="submit" class="btn-xs submit-post btn btn-primary" style="top:5px;">Submit</button>
+                            </div>
                           </form>
                         </div>
                         <% } %>

--- a/views/quickpost.ejs
+++ b/views/quickpost.ejs
@@ -12,7 +12,8 @@
                 <div class="form-group">
                   <br>
                     <label style = "font-size: 18px;" >Title</label>
-                    <input class="form-control input-lg" id="titlebox" type="text" placeholder="Question Title" name="title">
+                    <input class="form-control input-lg" id="titlebox" type="text" placeholder="Question Title" name="title" required='' oninvalid="this.setCustomValidity('Please enter your question!')"
+                    oninput="setCustomValidity('')">
                   </div>
                   <div>
                     <label style = "font-size: 18px;" for="questionDescription">Description</label>


### PR DESCRIPTION
- Issue: creating post without title messes up database
- Fix: now prompts user to input title before creating post and also prompts user to input comment on posts so no empty comment can be seen
- Updated submit button for editing post, and changed placement for homepage logo